### PR TITLE
Fix #31 by removing .expect() after sender.send()

### DIFF
--- a/clashctl/src/ui/utils/tui_logger.rs
+++ b/clashctl/src/ui/utils/tui_logger.rs
@@ -77,8 +77,8 @@ impl log::Log for Logger {
         }
         inner
             .sender
-            .send(Event::Diagnostic(DiagnosticEvent::Log(level, content)))
-            .expect("All receivers dropped");
+            .send(Event::Diagnostic(DiagnosticEvent::Log(level, content))).ok();
+            
     }
 
     fn flush(&self) {}


### PR DESCRIPTION
Fix #31.
The closure in `app.rs` take the ownership of the only receiver. When I quit, the infinte loop breaks and closure exits, then the receiver is dropped, which causes the panic whenever there are messages to be logged.
https://github.com/George-Miao/clashctl/blob/5167756723d555f34d057f572672344af90dc9c8/clashctl/src/ui/app.rs#L93-L120

The simple workaround is to remove `.expect()`. I think this makes sense because it shouldn't really be expected.